### PR TITLE
Add missing "apiVersion" to manifests for ConfigMaps

### DIFF
--- a/install/helm/templates/grafana-dashboards-configmap.yaml
+++ b/install/helm/templates/grafana-dashboards-configmap.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.grafana.enabled }}
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "lotus.fullname" . }}-grafana-dashboards

--- a/install/helm/templates/grafana-datasources-configmap.yaml
+++ b/install/helm/templates/grafana-datasources-configmap.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.grafana.enabled }}
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "lotus.fullname" . }}-grafana-datasources

--- a/install/manifests-norbac/grafana-dashboards-configmap.yaml
+++ b/install/manifests-norbac/grafana-dashboards-configmap.yaml
@@ -1,6 +1,7 @@
 ---
 # Source: lotus/templates/grafana-dashboards-configmap.yaml
 
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: lotus-grafana-dashboards

--- a/install/manifests-norbac/grafana-datasources-configmap.yaml
+++ b/install/manifests-norbac/grafana-datasources-configmap.yaml
@@ -1,6 +1,7 @@
 ---
 # Source: lotus/templates/grafana-datasources-configmap.yaml
 
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: lotus-grafana-datasources

--- a/install/manifests/grafana-dashboards-configmap.yaml
+++ b/install/manifests/grafana-dashboards-configmap.yaml
@@ -1,6 +1,7 @@
 ---
 # Source: lotus/templates/grafana-dashboards-configmap.yaml
 
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: lotus-grafana-dashboards

--- a/install/manifests/grafana-datasources-configmap.yaml
+++ b/install/manifests/grafana-datasources-configmap.yaml
@@ -1,6 +1,7 @@
 ---
 # Source: lotus/templates/grafana-datasources-configmap.yaml
 
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: lotus-grafana-datasources


### PR DESCRIPTION
This pull request adds missing "apiVersion" to manifests for ConfigMaps.
I got errors because of this missing "apiVersion" while I was installing lotus with helm.